### PR TITLE
fix double loading when using pause attribute on first click

### DIFF
--- a/ajax-load-more/core/js/ajax-load-more.js
+++ b/ajax-load-more/core/js/ajax-load-more.js
@@ -17,7 +17,7 @@
 		speed = 300,
 		proceed = false,
 		$init = true,
-		$loading = true,
+		$loading = false,
 		$finished = false,
 		$window = $(window),
 		$button_label = '',
@@ -93,6 +93,7 @@
 		// Load posts function
 		AjaxLoadMore.loadPosts = function() {
 			$button.addClass('loading');
+			$loading = true;
 			$.ajax({
 				type: "GET",
 				url: alm_localize.ajaxurl,
@@ -161,6 +162,7 @@
 				},
 				error: function(jqXHR, textStatus, errorThrown) {
 					$button.removeClass('loading');
+					$loading = false;
 					//alert(jqXHR + " :: " + textStatus + " :: " + errorThrown);
 				}
 			});


### PR DESCRIPTION
This shortcode use pause attribute and should load one post per click but the first click loads two posts.

```
<?php echo do_shortcode('[ajax_load_more posts_per_page="1" scroll="false" pause="true" transition="fade" button_label="Load Posts"]');?>
```
